### PR TITLE
Revert engine to node 18

### DIFF
--- a/packages/v1/certificates/package-lock.json
+++ b/packages/v1/certificates/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "certificate-fetcher",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "certificate-fetcher",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.18.4",
@@ -14,7 +14,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/packages/v1/certificates/package.json
+++ b/packages/v1/certificates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "certificate-fetcher",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A web service to fetch SSL certificates for a domain",
   "main": "lib/index.js",
   "scripts": {
@@ -14,7 +14,7 @@
     "url": "https://github.com/abappm/tools.abappm.com.git"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/v1/version-shield-json/package-lock.json
+++ b/packages/v1/version-shield-json/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "abap-package-version-shield",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "abap-package-version-shield",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
-        "fast-xml-parser": "^5.0.9"
+        "fast-xml-parser": "^5.2.2"
       },
       "devDependencies": {
         "eslint": "^9.35.0",
@@ -17,7 +17,7 @@
         "node-fetch": "^3.3.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2690,9 +2690,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.0.9.tgz",
-      "integrity": "sha512-2mBwCiuW3ycKQQ6SOesSB8WeF+fIGb6I/GG5vU5/XEptwFFhp9PE8b9O7fbs2dpq9fXn4ULR3UsfydNUCntf5A==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
       "funding": [
         {
           "type": "github",
@@ -2701,7 +2701,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.0.5"
+        "strnum": "^2.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -4891,9 +4891,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.0.5.tgz",
-      "integrity": "sha512-YAT3K/sgpCUxhxNMrrdhtod3jckkpYwH6JAuwmUdXZsmzH1wUyzTMrrK2wYCEEqlKwrWDd35NeuUkbBy/1iK+Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
       "funding": [
         {
           "type": "github",

--- a/packages/v1/version-shield-json/package.json
+++ b/packages/v1/version-shield-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abap-package-version-shield",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Custom handler for shields.io to display abap package version",
   "main": "index.js",
   "repository": {
@@ -17,7 +17,7 @@
   },
   "author": "Alexander Tsybulsky",
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "license": "ISC",
   "devDependencies": {


### PR DESCRIPTION
Only node 18 is supported for DigitalOcean serverless functions
https://docs.digitalocean.com/products/functions/details/features/#supported-runtimes